### PR TITLE
fix checkmate eval is none

### DIFF
--- a/src/pipeline_import/transforms.py
+++ b/src/pipeline_import/transforms.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from subprocess import SubprocessError
 from typing import Type
 
+import chess
 import lichess.api
 import pandas as pd
 import stockfish
@@ -25,7 +26,7 @@ from utils.types import Json, Visitor
 def get_sf_evaluation(fen: str,
                       sf_location: Path,
                       sf_depth: int,
-                      ) -> float | None:
+                      ) -> float:
     # get cloud eval if available
     try:
         cloud_eval = lichess.api.cloud_eval(fen=fen, multiPv=1)
@@ -71,7 +72,15 @@ def get_sf_evaluation(fen: str,
             rating *= -1
         rating /= 100
     else:
-        rating = None
+        board = chess.Board(fen)
+        if board.is_checkmate():
+            if board.outcome().winner is chess.WHITE:
+                rating = 9999
+            else:
+                rating = -9999
+        else:
+            raise ValueError('No best move found and not a checkmate position '
+                             f'for: {fen=} {sf.info=}')
 
     return rating
 

--- a/src/vendors/stockfish.py
+++ b/src/vendors/stockfish.py
@@ -51,13 +51,9 @@ def get_evals(df: pd.DataFrame,
                 # position will be dropped later if evaluation is None
                 evaluation = None
             else:
-                sf_eval: float | None = get_sf_evaluation(position + ' 0',
-                                                          sf_params.location,
-                                                          sf_params.depth)
-                if sf_eval is not None:
-                    # TODO: this is implicitly setting evaluation = last
-                    # eval if in a checkmate position. handle this better
-                    evaluation = sf_eval
+                evaluation = get_sf_evaluation(position + ' 0',
+                                               sf_params.location,
+                                               sf_params.depth)
 
             local_evals.append(evaluation)
 

--- a/tests/vendors/test_stockfish.py
+++ b/tests/vendors/test_stockfish.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytest
+from vendors.stockfish import get_evals
+
+
+@pytest.fixture
+def mock_run_remote_sql_query(mocker):
+    mocker.patch('vendors.stockfish.run_remote_sql_query',
+                 return_value=pd.DataFrame([], columns=['fen']),
+                 )
+
+
+@pytest.fixture
+def mock_task(mocker):
+    return mocker.MagicMock()
+
+
+def test_get_evals_on_checkmate_position(mock_run_remote_sql_query, mock_task):
+    fen = 'rnb1k1nr/pp1p1ppp/4p3/8/8/1P2qN2/PBPKPbPP/RN1Q1B1R w kq - 2 7'
+
+    df = pd.DataFrame([[None, None, fen]],
+                      columns=['evaluations', 'eval_depths', 'positions'],
+                      )
+    actual = get_evals(df, local_stockfish=True, task=mock_task)
+
+    expected = pd.DataFrame([[fen[:-2], -9999.0, 1]],
+                            columns=['fen', 'evaluation', 'eval_depth'])
+    expected['eval_depth'] = expected['eval_depth'].astype(object)
+
+    pd.testing.assert_frame_equal(actual, expected)


### PR DESCRIPTION
The checkmate eval is returning `None` which causes a lot of downstream problems. This isn't usually a problem because a checkmate only happens in a mate-in-1 position, so the eval from a previous position that is examined carries forward to the checkmate position, but if said mate-in-1 position is skipped in the eval analysis, this leads to errors estimating win probabilities.

This PR fixes this by checking whether the position is checkmate and returning 9999 / -9999 depending on the winner. As a result, `get_sf_evaluation` never returns `None`, so I cleaned up some code and made it a little more straightforward.

Finally, I added a test for a checkmate position so that this error hopefully does not happen again.