### PR TITLE
use lichess client with max retries to avoid getting stuck on evaluation api call

### DIFF
--- a/src/pipeline_import/transforms.py
+++ b/src/pipeline_import/transforms.py
@@ -23,13 +23,18 @@ from psycopg2 import connect
 from utils.types import Json, Visitor
 
 
+class LichessApiClient(lichess.api.DefaultApiClient):
+    max_retries = 3
+
+
 def get_sf_evaluation(fen: str,
                       sf_location: Path,
                       sf_depth: int,
                       ) -> float:
     # get cloud eval if available
     try:
-        cloud_eval = lichess.api.cloud_eval(fen=fen, multiPv=1)
+        client = LichessApiClient()
+        cloud_eval = lichess.api.cloud_eval(fen=fen, multiPv=1, client=client)
         rating = cloud_eval['pvs'][0]
         if 'cp' in rating:
             rating = rating['cp'] / 100


### PR DESCRIPTION
The lichess API has a 3000 evals/day rate limit, and if we hit that then the code gets stuck because there's no timeout option and no max retries.

Subclass the `python-lichess` `DefaultApiClient` and set max retries so that if we fail 3 times with 429 codes, then it'll just fall back to evaluating with local stockfish.